### PR TITLE
Fix generated examples links in demo site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -243,26 +243,26 @@
                         <div class="file-card">
                             <div class="file-icon">📊</div>
                             <h4>Dashboard</h4>
-                            <p>12 panels covering health, SLOs, latency, errors, and dependencies</p>
-                            <a href="https://github.com/rsionnach/nthlayer/tree/main/generated/examples/payment-api" target="_blank">View JSON →</a>
+                            <p>22 panels covering health, SLOs, latency, errors, and dependencies</p>
+                            <a href="https://github.com/rsionnach/nthlayer/blob/develop/generated/payment-api/dashboard-sdk.json" target="_blank">View JSON →</a>
                         </div>
                         <div class="file-card">
                             <div class="file-icon">🎯</div>
                             <h4>SLOs</h4>
                             <p>3 SLOs with 30-day error budgets and burn rate calculations</p>
-                            <a href="https://github.com/rsionnach/nthlayer/tree/main/generated/examples/payment-api" target="_blank">View YAML →</a>
+                            <a href="https://github.com/rsionnach/nthlayer/blob/develop/generated/payment-api/slos.yaml" target="_blank">View YAML →</a>
                         </div>
                         <div class="file-card">
                             <div class="file-icon">🚨</div>
                             <h4>Alerts</h4>
                             <p>28 Prometheus alerts with smart routing and severity levels</p>
-                            <a href="https://github.com/rsionnach/nthlayer/tree/main/generated/examples/payment-api" target="_blank">View YAML →</a>
+                            <a href="https://github.com/rsionnach/nthlayer/blob/develop/generated/payment-api/alerts.yaml" target="_blank">View YAML →</a>
                         </div>
                         <div class="file-card">
                             <div class="file-icon">⚡</div>
                             <h4>Recording Rules</h4>
                             <p>21 pre-aggregated metrics for 10x faster dashboard queries</p>
-                            <a href="https://github.com/rsionnach/nthlayer/tree/main/generated/examples/payment-api" target="_blank">View YAML →</a>
+                            <a href="https://github.com/rsionnach/nthlayer/blob/develop/generated/payment-api/recording-rules.yaml" target="_blank">View YAML →</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Fixes broken links in the GitHub Pages demo site's "Explore what was generated" section.

### Changes
- Point to actual files instead of non-existent `examples` folder
- Links now target specific files:
  - `generated/payment-api/dashboard-sdk.json`
  - `generated/payment-api/slos.yaml`
  - `generated/payment-api/alerts.yaml`
  - `generated/payment-api/recording-rules.yaml`
- Updated panel count from 12 to 22 (actual current count)

### Testing
Links verified working at https://rsionnach.github.io/nthlayer/

---
*This PR was created by Droid*