### PR TITLE
Increase logo size for better visibility

### DIFF
--- a/docs/demo-comparison.html
+++ b/docs/demo-comparison.html
@@ -10,7 +10,7 @@
     <nav class="nav">
         <div class="nav-container">
             <div class="nav-logo">
-                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="32">
+                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="48">
             </div>
             <div class="nav-links">
                 <a href="index.html">Demo</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
     <nav class="nav">
         <div class="nav-container">
             <div class="nav-logo">
-                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="32">
+                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="48">
             </div>
             <div class="nav-links">
                 <a href="https://github.com/rsionnach/nthlayer" target="_blank">GitHub</a>
@@ -309,7 +309,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="nthlayer_dark_logo.png" alt="NthLayer" height="24">
+                    <img src="nthlayer_dark_logo.png" alt="NthLayer" height="36">
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/rsionnach/nthlayer">GitHub</a>

--- a/docs/roi-calculator.html
+++ b/docs/roi-calculator.html
@@ -10,7 +10,7 @@
     <nav class="nav">
         <div class="nav-container">
             <div class="nav-logo">
-                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="32">
+                <img src="nthlayer_dark_logo.png" alt="NthLayer" height="48">
             </div>
             <div class="nav-links">
                 <a href="index.html">Demo</a>


### PR DESCRIPTION
## Summary

Makes the NthLayer logo larger and easier to see on the demo site.

### Changes
- Nav logo: 32px → 48px
- Footer logo: 24px → 36px

---
*This PR was created by Droid*