### PR TITLE
Release: Documentation overhaul, CLI UX, conftest validation, and more

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,138 +5,133 @@ from nthlayer.cli.init import _is_valid_service_name, init_command
 
 class TestInitCommand:
     """Tests for init_command function."""
-    
+
     def test_init_creates_service_file(self, tmp_path, monkeypatch):
         """Should create service YAML file."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
-            service_name="my-api",
-            team="my-team",
-            template="critical-api",
-            interactive=False
+            service_name="my-api", team="my-team", template="critical-api", interactive=False
         )
-        
+
         assert result == 0
         assert (tmp_path / "my-api.yaml").exists()
-        
+
         # Check file content
         content = (tmp_path / "my-api.yaml").read_text()
         assert "name: my-api" in content
         assert "team: my-team" in content
         assert "template: critical-api" in content
-    
+
     def test_init_creates_config_directory(self, tmp_path, monkeypatch):
         """Should create .nthlayer directory and config."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         assert result == 0
         assert (tmp_path / ".nthlayer").exists()
         assert (tmp_path / ".nthlayer" / "config.yaml").exists()
-        
+
         # Check config content
         config = (tmp_path / ".nthlayer" / "config.yaml").read_text()
         assert "error_budgets" in config
         assert "inherited_attribution" in config
-    
+
     def test_init_does_not_overwrite_config(self, tmp_path, monkeypatch):
         """Should not overwrite existing config file."""
         monkeypatch.chdir(tmp_path)
-        
+
         # Create existing config
         (tmp_path / ".nthlayer").mkdir()
         (tmp_path / ".nthlayer" / "config.yaml").write_text("existing: config")
-        
+
         result = init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         assert result == 0
         # Should not overwrite
         config = (tmp_path / ".nthlayer" / "config.yaml").read_text()
         assert config == "existing: config"
-    
+
     def test_init_rejects_existing_file(self, tmp_path, monkeypatch):
         """Should error if service file already exists."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "my-api.yaml").write_text("existing")
-        
+
         result = init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         assert result == 1  # Error
-    
+
     def test_init_requires_service_name(self, tmp_path, monkeypatch):
         """Should error if service name not provided in non-interactive mode."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
-            service_name=None,
-            team="my-team",
-            template="critical-api",
-            interactive=False
+            service_name=None, team="my-team", template="critical-api", interactive=False
         )
-        
+
         assert result == 1
-    
+
     def test_init_requires_team(self, tmp_path, monkeypatch):
         """Should error if team not provided in non-interactive mode."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
-            service_name="my-api",
-            team=None,
-            template="critical-api",
-            interactive=False
+            service_name="my-api", team=None, template="critical-api", interactive=False
         )
-        
+
         assert result == 1
-    
-    def test_init_requires_template(self, tmp_path, monkeypatch):
-        """Should error if template not provided in non-interactive mode."""
+
+    def test_init_works_without_template(self, tmp_path, monkeypatch):
+        """Should work without template in non-interactive mode (uses defaults)."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
-            service_name="my-api",
-            team="my-team",
-            template=None,
-            interactive=False
+            service_name="my-api", team="my-team", template=None, interactive=False
         )
-        
-        assert result == 1
-    
+
+        # Should succeed with default tier=standard, type=api
+        assert result == 0
+        assert (tmp_path / "my-api.yaml").exists()
+
+        content = (tmp_path / "my-api.yaml").read_text()
+        assert "name: my-api" in content
+        assert "tier: standard" in content
+        assert "type: api" in content
+
     def test_init_rejects_unknown_template(self, tmp_path, monkeypatch):
         """Should error on unknown template."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
             service_name="my-api",
             team="my-team",
             template="nonexistent-template",
-            interactive=False
+            interactive=False,
         )
-        
+
         assert result == 1
-    
+
     def test_init_with_different_templates(self, tmp_path, monkeypatch):
         """Should work with different template types."""
         monkeypatch.chdir(tmp_path)
-        
+
         templates = ["critical-api", "standard-api", "low-api", "background-job", "pipeline"]
-        
+
         for template in templates:
             service_name = f"test-{template}"
             result = init_command(service_name, "team", template, interactive=False)
-            
+
             assert result == 0
             assert (tmp_path / f"{service_name}.yaml").exists()
-            
+
             content = (tmp_path / f"{service_name}.yaml").read_text()
             assert f"template: {template}" in content
 
 
 class TestServiceNameValidation:
     """Tests for service name validation."""
-    
+
     def test_valid_service_names(self):
         """Should accept valid service names."""
         valid_names = [
@@ -147,10 +142,10 @@ class TestServiceNameValidation:
             "service123",
             "my-api-v1",
         ]
-        
+
         for name in valid_names:
             assert _is_valid_service_name(name), f"{name} should be valid"
-    
+
     def test_invalid_service_names(self):
         """Should reject invalid service names."""
         invalid_names = [
@@ -163,71 +158,71 @@ class TestServiceNameValidation:
             "",  # empty
             "my.api",  # period
         ]
-        
+
         for name in invalid_names:
             if name == "my--api":
                 # Double hyphen is actually valid
                 assert _is_valid_service_name(name)
             else:
                 assert not _is_valid_service_name(name), f"{name} should be invalid"
-    
+
     def test_init_rejects_invalid_name(self, tmp_path, monkeypatch):
         """Should error on invalid service name."""
         monkeypatch.chdir(tmp_path)
-        
+
         result = init_command(
             service_name="MyInvalidApi",  # uppercase
             team="my-team",
             template="critical-api",
-            interactive=False
+            interactive=False,
         )
-        
+
         assert result == 1
 
 
 class TestGeneratedServiceFile:
     """Tests for generated service file content."""
-    
+
     def test_generated_file_is_valid_yaml(self, tmp_path, monkeypatch):
         """Generated file should be valid YAML."""
         monkeypatch.chdir(tmp_path)
-        
+
         init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         # Should be parseable
         import yaml
+
         with open(tmp_path / "my-api.yaml") as f:
             data = yaml.safe_load(f)
-        
+
         assert data["service"]["name"] == "my-api"
         assert data["service"]["team"] == "my-team"
         assert data["service"]["template"] == "critical-api"
-    
+
     def test_generated_file_validates(self, tmp_path, monkeypatch):
         """Generated file should pass validation."""
         monkeypatch.chdir(tmp_path)
-        
+
         init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         # Should be parseable by our parser
         from nthlayer.specs.parser import parse_service_file
-        
+
         context, resources = parse_service_file(tmp_path / "my-api.yaml")
-        
+
         assert context.name == "my-api"
         assert context.team == "my-team"
         assert context.template == "critical-api"
         assert len(resources) == 3  # From template
-    
+
     def test_generated_file_includes_comments(self, tmp_path, monkeypatch):
         """Generated file should include helpful comments."""
         monkeypatch.chdir(tmp_path)
-        
+
         init_command("my-api", "my-team", "critical-api", interactive=False)
-        
+
         content = (tmp_path / "my-api.yaml").read_text()
-        
-        # Should have comments
-        assert "# Template provides:" in content
-        assert "# Optional:" in content
-        assert "# Override" in content  # "Override template defaults or add new resources"
+
+        # Should have header comments
+        assert "# my-api Service Definition" in content
+        assert "# Generated by NthLayer" in content


### PR DESCRIPTION
## Summary

This PR includes significant improvements across documentation, CLI UX, and validation features.

## Major Changes

### Documentation Overhaul
- **Restructured navigation** with Generate/Validate/Protect sections
- **New pages**: CI/CD integrations, validate-spec, init command, validation overview, protection overview
- **Updated homepage** with pipeline-focused messaging and GIF demos
- **Fresh VHS recordings** for all key commands

### CLI UX Improvements
- **Interactive init wizard** with tier/type/dependency selection
- **Setup wizard** with questionary/gum prompts
- **Styled output** across all commands

### conftest/OPA Policy Validation
- **3 Rego policy files** (service, SLO, dependencies)
- **`nthlayer validate-spec`** command with native fallback
- **16 tests** covering all validators

### Other Improvements
- Phase 2.5: Loki integration with 15+ technology templates
- Phase 3: SLO Portfolio with live Prometheus queries
- Phase 3.5: Enhanced validation with 10 metadata validators
- Phase 5: Deployment gates with policy DSL
- Mimir/Cortex Ruler API integration
- Beads updates tracking all completed work

## Commits (16)

```
e99d9b4 test: Update init tests for template-optional behavior
77ddcd0 chore: Rebuild documentation site
d93ab4e docs: Restructure documentation with Generate/Validate/Protect sections
8a39c9f chore: Update beads - close conftest and CLI init wizard
7699875 feat: Update setup wizard with interactive prompts
b7fffc7 chore: Update beads - close conftest and CLI init wizard
1ffe073 feat: Enhance init wizard with interactive prompts
ac1a6de feat: Add conftest/OPA policy validation for service specs
2e6e496 chore: Add GitHub Actions Marketplace and Backstage to roadmap
006a40b chore: Update beads with Phase 2.5, 3, 3.5, and 5 completion
53abe9d feat: Complete Phase 3.5 - Enhanced Validation
f78b490 feat: Complete Phase 2.5 - Loki CLI command
1261891 feat: Complete Phase 5 - Deployment Gates
10d5eb3 feat: Enhance portfolio command
c5bc33d docs: Revise Phase 3 to lean SLO Portfolio
+ more...
```

## Testing

- All 163 tests passing
- Lint and typecheck clean
- VHS demos regenerated