### PR TITLE
feat: on-call schedule schema (opensrm-0rg.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,11 @@ When fixing a GitHub Issue: `fix: <description> (<bead-id>, closes #<number>)`
     - `codeowners.py` - Static: reads CODEOWNERS file from repo (confidence=0.85); remains in nthlayer (generate-only)
 - `specs/` - Service specification models and parsing
   - `helpers.py` - Shared utilities: `TECH_KEYWORDS` constant, `infer_technology_from_name()` function
-  - `manifest.py` - ReliabilityManifest unified model (OpenSRM + legacy); `BudgetPolicy`, `BudgetThresholds`, `ErrorBudgetGate` dataclasses for error budget policy DSL
+  - `manifest.py` - ReliabilityManifest unified model (OpenSRM + legacy); `BudgetPolicy`, `BudgetThresholds`, `ErrorBudgetGate` dataclasses for error budget policy DSL; ownership/oncall dataclasses: `PagerDutyConfig`, `RosterMember` (name, slack_id, ntfy_topic?, phone?), `Override` (start/end ISO 8601, user, reason?), `ManifestEscalationStep` (after, notify "slack_dm"|"ntfy"|"slack_channel"|"phone"|"pagerduty", target?, phone?), `RotationConfig` (type "weekly"|"daily", handoff, roster), `OnCallConfig` (timezone IANA, rotation, overrides, escalation); `Ownership` dataclass includes `oncall: OnCallConfig | None`
   - `alerting.py` - `AlertingConfig`, `ForDuration` dataclasses; `ForDuration.get_for_severity()` maps severity → `for` duration override
   - `loader.py` - Auto-detect format and load manifests
   - `parser.py` - Legacy format parser, `render_resource_spec()` for variable substitution
-  - `opensrm_parser.py` - OpenSRM YAML parser; `_parse_budget_policy()` helper constructs `BudgetPolicy` from gate config
+  - `opensrm_parser.py` - OpenSRM YAML parser; `_parse_budget_policy()` helper constructs `BudgetPolicy` from gate config; `_parse_ownership()` calls `_parse_oncall()` for `spec.ownership.oncall`; `_parse_oncall()` builds `RosterMember` list (requires name+slack_id), `Override` list (requires start+end+user), `ManifestEscalationStep` list (requires after+notify), validates IANA timezone via `ZoneInfo`; raises `OpenSRMParseError` for missing required fields or invalid timezone
 - `slos/` - SLO definition, validation, and recording rule generation (runtime infra deleted B3 ✓ done 2026-04-09)
   - `models.py` - Re-export shim → canonical source is `nthlayer_common.slo_models` (Phase 0 done); exports SLO, ErrorBudget, SLOStatus, TimeWindow, TimeWindowType, Incident for backward compat
   - `parser.py` - OpenSLO YAML parsing
@@ -369,6 +369,8 @@ P0–P5 copied runtime code to nthlayer-observe. The Purify Generate epic delete
 - Deployed to GitHub Pages at rsionnach.github.io/nthlayer/
 - Source docs in `docs-site/`, built output in `site/` (gitignored)
 - Assets: Custom CSS (stylesheets/nord.css), Mermaid config (javascripts/mermaid-config.js)
+- **Known docs drift:** `docs-site/commands/index.md` and `docs-site/index.md` still list `check-deploy`, `drift`, `portfolio`, `scorecard`, `blast-radius`, `deps` as nthlayer commands — these have all migrated to nthlayer-observe and need a docs update pass
+- `docs-site/commands/alerts.md` correctly notes budget explanations redirect: `nthlayer-observe explain --store assessments.db --service <service>` (the `alerts explain` subcommand was deleted in nthlayer-hmj)
 
 ### Execution Plan Tracking
 - Plans in `plans/` track spec implementation lifecycle
@@ -587,7 +589,7 @@ P0–P5 copied runtime code to nthlayer-observe. The Purify Generate epic delete
 
 ### Optional Dependency Groups
 - Install with extras for optional integrations: `pip install -e ".[aws]"`, `pip install -e ".[kubernetes]"`
-- `[aws]`: boto3, aioboto3 — required for CloudWatch and SQS modules
+- `[aws]`: boto3 only — required for `AWSSecretBackend` in `config/secrets/backends.py` (CloudWatch/SQS modules deleted in B7)
 - `[kubernetes]`: kubernetes client — required for K8s dependency discovery provider
 - `[zookeeper]`: kazoo — required for Zookeeper discovery provider
 - `[etcd]`: etcd3 — required for etcd discovery provider
@@ -602,9 +604,9 @@ P0–P5 copied runtime code to nthlayer-observe. The Purify Generate epic delete
 - Integration tests using mock servers live in `tests/integration/` (e.g., `tests/integration/test_mock_server_integration.py`)
 - CLI end-to-end smoke tests live in `tests/smoke/` — invoke the real CLI via subprocess; see "CLI Smoke Test Suite" pattern for details
 - **Unit tests for CLI commands** live in `tests/test_cli_*.py` — use `capsys`/`tmp_path`/`unittest.mock.patch` (no subprocess): `test_cli_alerts.py` (alerts show/evaluate/explain/test, respx mocking), `test_cli_dashboard.py` (generate_dashboard_command, dry-run, default path), `test_cli_dashboard_validate.py` (validate_dashboard_command exit codes 0/1/2, list_intents_command), `test_cli_environments.py` (list/diff/validate env commands), `test_cli_generate.py` (generate_slo_command, sloth-only format support), `test_cli_setup.py` (setup wizard, connection testing, GrafanaProfile/PrometheusProfile fixtures), `test_cli_validate_slo.py` (PromQL extraction, SLOValidationResult, demo mode)
-- **Unit tests for providers/identity**: `tests/test_prometheus_provider.py` (PrometheusProvider init, query, query_range; uses AsyncMock on `_request`), `tests/test_ownership.py` (OwnershipSource/Signal/Attribution, DeclaredOwnershipProvider, CODEOWNERSProvider; pytest.mark.asyncio)
+- **Unit tests for providers/identity**: `tests/test_prometheus_provider.py` (PrometheusProvider init, query, query_range; uses AsyncMock on `_request`), `tests/test_ownership.py` (OwnershipSource/Signal/Attribution, DeclaredOwnershipProvider, CODEOWNERSProvider; pytest.mark.asyncio), `tests/test_mimir_provider.py` (MimirRulerProvider init/headers, push_rules, delete_rules, list_rules, health_check, RulerPushResult; TestBackwardCompat verifies all 3 import paths resolve to same class: `nthlayer.providers.mimir` → `nthlayer_common.providers.mimir` → `nthlayer_common.clients.mimir`; all async tests use pytest.mark.asyncio with patch.object on `_request`)
 - Shared pytest config (structlog suppression, fixtures) lives in `tests/conftest.py`
-- Tests for optional-dependency modules use `pytest.importorskip("package")` at module level to skip when extras are not installed: `aioboto3 = pytest.importorskip("aioboto3", reason="aioboto3 is required for workers tests")`
+- Tests for optional-dependency modules use `pytest.importorskip("package")` at module level to skip when extras are not installed: `kubernetes = pytest.importorskip("kubernetes", reason="kubernetes is required for K8s provider tests")`
 - Apply `importorskip` to any test module that imports from `[aws]`, `[kubernetes]`, or other optional extras
 
 ### Async/Await Usage

--- a/src/nthlayer/specs/manifest.py
+++ b/src/nthlayer/specs/manifest.py
@@ -102,6 +102,59 @@ class PagerDutyConfig:
 
 
 @dataclass
+class RosterMember:
+    """A person in the on-call rotation roster."""
+
+    name: str
+    slack_id: str
+    ntfy_topic: str | None = None
+    phone: str | None = None
+
+
+@dataclass
+class Override:
+    """Manual on-call override (holidays, swaps)."""
+
+    start: str  # ISO 8601
+    end: str  # ISO 8601
+    user: str
+    reason: str | None = None
+
+
+@dataclass
+class ManifestEscalationStep:
+    """A single step in the escalation policy (build-time schema).
+
+    Prefixed with 'Manifest' to distinguish from the runtime
+    EscalationStep in nthlayer_respond.oncall.escalation (Phase 3).
+    """
+
+    after: str  # e.g. "0m", "5m", "10m"
+    notify: str  # "slack_dm" | "ntfy" | "slack_channel" | "phone" | "pagerduty"
+    target: str | None = None  # "next_oncall" | "engineering_manager"
+    phone: str | None = None  # direct phone override for this step
+
+
+@dataclass
+class RotationConfig:
+    """On-call rotation schedule configuration."""
+
+    type: str  # "weekly" | "daily"
+    handoff: str  # e.g. "monday 09:00" or "09:00"
+    roster: list[RosterMember] = field(default_factory=list)
+
+
+@dataclass
+class OnCallConfig:
+    """On-call configuration within spec.ownership."""
+
+    timezone: str  # IANA timezone string
+    rotation: RotationConfig
+    overrides: list[Override] = field(default_factory=list)
+    escalation: list[ManifestEscalationStep] = field(default_factory=list)
+
+
+@dataclass
 class Ownership:
     """Service ownership information (OpenSRM spec.ownership)."""
 
@@ -112,6 +165,7 @@ class Ownership:
     pagerduty: PagerDutyConfig | None = None
     runbook: str | None = None
     documentation: str | None = None
+    oncall: OnCallConfig | None = None
 
 
 # =============================================================================

--- a/src/nthlayer/specs/opensrm_parser.py
+++ b/src/nthlayer/specs/opensrm_parser.py
@@ -41,12 +41,17 @@ from nthlayer.specs.manifest import (
     DeploymentGates,
     ErrorBudgetGate,
     Instrumentation,
+    ManifestEscalationStep,
     Observability,
+    OnCallConfig,
+    Override,
     Ownership,
     PagerDutyConfig,
     RecentIncidentsGate,
     ReliabilityManifest,
     RollbackConfig,
+    RosterMember,
+    RotationConfig,
     SLOComplianceGate,
     SLODefinition,
     SourceFormat,
@@ -303,6 +308,9 @@ def _parse_ownership(ownership_data: dict[str, Any] | None) -> Ownership | None:
             escalation_policy_id=pd_data.get("escalation_policy_id"),
         )
 
+    # Parse on-call config
+    oncall = _parse_oncall(ownership_data.get("oncall"))
+
     return Ownership(
         team=team,
         slack=ownership_data.get("slack"),
@@ -311,6 +319,87 @@ def _parse_ownership(ownership_data: dict[str, Any] | None) -> Ownership | None:
         pagerduty=pagerduty,
         runbook=ownership_data.get("runbook"),
         documentation=ownership_data.get("documentation"),
+        oncall=oncall,
+    )
+
+
+def _parse_oncall(oncall_data: dict[str, Any] | None) -> OnCallConfig | None:
+    """Parse on-call configuration from OpenSRM spec.ownership.oncall section."""
+    if not oncall_data:
+        return None
+
+    rotation_data = oncall_data.get("rotation", {})
+
+    roster = []
+    for i, raw_member in enumerate(rotation_data.get("roster", [])):
+        try:
+            roster.append(
+                RosterMember(
+                    name=raw_member["name"],
+                    slack_id=raw_member["slack_id"],
+                    ntfy_topic=raw_member.get("ntfy_topic"),
+                    phone=raw_member.get("phone"),
+                )
+            )
+        except KeyError as e:
+            raise OpenSRMParseError(
+                f"oncall.rotation.roster[{i}] missing required field: {e}"
+            ) from e
+
+    overrides = []
+    for i, raw_override in enumerate(oncall_data.get("overrides", [])):
+        try:
+            overrides.append(
+                Override(
+                    start=raw_override["start"],
+                    end=raw_override["end"],
+                    user=raw_override["user"],
+                    reason=raw_override.get("reason"),
+                )
+            )
+        except KeyError as e:
+            raise OpenSRMParseError(
+                f"oncall.overrides[{i}] missing required field: {e}"
+            ) from e
+
+    escalation = []
+    for i, raw_step in enumerate(oncall_data.get("escalation", [])):
+        try:
+            escalation.append(
+                ManifestEscalationStep(
+                    after=raw_step["after"],
+                    notify=raw_step["notify"],
+                    target=raw_step.get("target"),
+                    phone=raw_step.get("phone"),
+                )
+            )
+        except KeyError as e:
+            raise OpenSRMParseError(
+                f"oncall.escalation[{i}] missing required field: {e}"
+            ) from e
+
+    # Validate timezone
+    tz_name = oncall_data.get("timezone")
+    if not tz_name:
+        raise OpenSRMParseError("oncall.timezone is required")
+    try:
+        from zoneinfo import ZoneInfo
+
+        ZoneInfo(tz_name)
+    except (KeyError, ValueError):
+        raise OpenSRMParseError(
+            f"oncall.timezone: invalid IANA timezone: {tz_name!r}"
+        ) from None
+
+    return OnCallConfig(
+        timezone=tz_name,
+        rotation=RotationConfig(
+            type=rotation_data.get("type", "weekly"),
+            handoff=rotation_data.get("handoff", "monday 09:00"),
+            roster=roster,
+        ),
+        overrides=overrides,
+        escalation=escalation,
     )
 
 

--- a/tests/test_opensrm.py
+++ b/tests/test_opensrm.py
@@ -11,6 +11,11 @@ from nthlayer.specs.manifest import (
     VALID_SERVICE_TYPES,
     VALID_TIERS,
     Dependency,
+    ManifestEscalationStep,
+    OnCallConfig,
+    Override,
+    RosterMember,
+    RotationConfig,
     SourceFormat,
 )
 from nthlayer.specs.opensrm_parser import (
@@ -1168,6 +1173,331 @@ class TestOpenSRMParserOwnershipEdgeCases:
         assert manifest.ownership is not None
         assert manifest.ownership.pagerduty is not None
         assert manifest.ownership.pagerduty.service_id == "PD123"
+
+
+class TestOnCallConfig:
+    """Test OnCallConfig dataclasses and oncall parsing."""
+
+    def _make_manifest_with_oncall(self, oncall_data: dict) -> dict:
+        """Helper: build a minimal OpenSRM manifest with oncall block."""
+        return {
+            "apiVersion": "srm/v1",
+            "kind": "ServiceReliabilityManifest",
+            "metadata": {
+                "name": "fraud-detect",
+                "team": "ml-platform",
+                "tier": "critical",
+            },
+            "spec": {
+                "type": "ai-gate",
+                "ownership": {
+                    "team": "ml-platform",
+                    "slack": "#ml-platform-oncall",
+                    "oncall": oncall_data,
+                },
+            },
+        }
+
+    def test_roster_member_dataclass(self):
+        """Test RosterMember has the expected fields."""
+        member = RosterMember(
+            name="Alice",
+            slack_id="U0123ALICE",
+            ntfy_topic="oncall-alice",
+            phone="+353851234567",
+        )
+        assert member.name == "Alice"
+        assert member.slack_id == "U0123ALICE"
+        assert member.ntfy_topic == "oncall-alice"
+        assert member.phone == "+353851234567"
+
+    def test_roster_member_optional_fields(self):
+        """Test RosterMember with only required fields."""
+        member = RosterMember(name="Bob", slack_id="U0456BOB")
+        assert member.ntfy_topic is None
+        assert member.phone is None
+
+    def test_override_dataclass(self):
+        """Test Override has the expected fields."""
+        override = Override(
+            start="2026-04-14T00:00:00Z",
+            end="2026-04-21T00:00:00Z",
+            user="Bob",
+            reason="Alice on annual leave",
+        )
+        assert override.start == "2026-04-14T00:00:00Z"
+        assert override.user == "Bob"
+        assert override.reason == "Alice on annual leave"
+
+    def test_override_optional_reason(self):
+        """Test Override with no reason."""
+        override = Override(
+            start="2026-04-14T00:00:00Z",
+            end="2026-04-21T00:00:00Z",
+            user="Bob",
+        )
+        assert override.reason is None
+
+    def test_escalation_step_dataclass(self):
+        """Test ManifestEscalationStep has the expected fields."""
+        step = ManifestEscalationStep(
+            after="5m",
+            notify="ntfy",
+            target="next_oncall",
+        )
+        assert step.after == "5m"
+        assert step.notify == "ntfy"
+        assert step.target == "next_oncall"
+        assert step.phone is None
+
+    def test_rotation_config_dataclass(self):
+        """Test RotationConfig with roster."""
+        roster = [
+            RosterMember(name="Alice", slack_id="U01"),
+            RosterMember(name="Bob", slack_id="U02"),
+        ]
+        config = RotationConfig(type="weekly", handoff="monday 09:00", roster=roster)
+        assert config.type == "weekly"
+        assert config.handoff == "monday 09:00"
+        assert len(config.roster) == 2
+
+    def test_oncall_config_full(self):
+        """Test OnCallConfig with all fields."""
+        config = OnCallConfig(
+            timezone="Europe/Dublin",
+            rotation=RotationConfig(
+                type="weekly",
+                handoff="monday 09:00",
+                roster=[RosterMember(name="Alice", slack_id="U01")],
+            ),
+            overrides=[
+                Override(
+                    start="2026-04-14T00:00:00Z",
+                    end="2026-04-21T00:00:00Z",
+                    user="Bob",
+                ),
+            ],
+            escalation=[
+                ManifestEscalationStep(after="0m", notify="slack_dm"),
+                ManifestEscalationStep(after="5m", notify="ntfy"),
+            ],
+        )
+        assert config.timezone == "Europe/Dublin"
+        assert config.rotation.type == "weekly"
+        assert len(config.overrides) == 1
+        assert len(config.escalation) == 2
+
+    def test_ownership_with_oncall_parsed(self):
+        """Test that oncall block is parsed from OpenSRM manifest."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "Europe/Dublin",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [
+                        {
+                            "name": "Alice",
+                            "slack_id": "U0123ALICE",
+                            "ntfy_topic": "oncall-alice",
+                            "phone": "+353851234567",
+                        },
+                        {
+                            "name": "Bob",
+                            "slack_id": "U0456BOB",
+                            "ntfy_topic": "oncall-bob",
+                        },
+                    ],
+                },
+                "overrides": [
+                    {
+                        "start": "2026-04-14T00:00:00Z",
+                        "end": "2026-04-21T00:00:00Z",
+                        "user": "Bob",
+                        "reason": "Alice on annual leave",
+                    },
+                ],
+                "escalation": [
+                    {"after": "0m", "notify": "slack_dm"},
+                    {"after": "5m", "notify": "ntfy"},
+                    {"after": "10m", "notify": "slack_dm", "target": "next_oncall"},
+                ],
+            }
+        )
+        manifest = parse_opensrm(data)
+        assert manifest.ownership is not None
+        assert manifest.ownership.oncall is not None
+
+        oncall = manifest.ownership.oncall
+        assert oncall.timezone == "Europe/Dublin"
+        assert oncall.rotation.type == "weekly"
+        assert oncall.rotation.handoff == "monday 09:00"
+        assert len(oncall.rotation.roster) == 2
+        assert oncall.rotation.roster[0].name == "Alice"
+        assert oncall.rotation.roster[0].slack_id == "U0123ALICE"
+        assert oncall.rotation.roster[0].ntfy_topic == "oncall-alice"
+        assert oncall.rotation.roster[0].phone == "+353851234567"
+        assert oncall.rotation.roster[1].ntfy_topic == "oncall-bob"
+        assert oncall.rotation.roster[1].phone is None
+
+        assert len(oncall.overrides) == 1
+        assert oncall.overrides[0].user == "Bob"
+        assert oncall.overrides[0].reason == "Alice on annual leave"
+
+        assert len(oncall.escalation) == 3
+        assert oncall.escalation[0].after == "0m"
+        assert oncall.escalation[0].notify == "slack_dm"
+        assert oncall.escalation[0].target is None
+        assert oncall.escalation[2].target == "next_oncall"
+
+    def test_ownership_without_oncall(self):
+        """Test that ownership without oncall block has oncall=None."""
+        data = {
+            "apiVersion": "srm/v1",
+            "kind": "ServiceReliabilityManifest",
+            "metadata": {
+                "name": "test",
+                "team": "test",
+                "tier": "standard",
+            },
+            "spec": {
+                "type": "api",
+                "ownership": {
+                    "team": "test",
+                    "slack": "#alerts",
+                },
+            },
+        }
+        manifest = parse_opensrm(data)
+        assert manifest.ownership is not None
+        assert manifest.ownership.oncall is None
+
+    def test_oncall_minimal(self):
+        """Test oncall with only required fields (no overrides, no escalation)."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "UTC",
+                "rotation": {
+                    "type": "daily",
+                    "handoff": "09:00",
+                    "roster": [
+                        {"name": "Alice", "slack_id": "U01"},
+                    ],
+                },
+            }
+        )
+        manifest = parse_opensrm(data)
+        oncall = manifest.ownership.oncall
+        assert oncall is not None
+        assert oncall.timezone == "UTC"
+        assert oncall.rotation.type == "daily"
+        assert len(oncall.overrides) == 0
+        assert len(oncall.escalation) == 0
+
+    def test_escalation_step_with_phone_override(self):
+        """Test escalation step with direct phone number for engineering_manager."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "Europe/Dublin",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"name": "Alice", "slack_id": "U01"}],
+                },
+                "escalation": [
+                    {
+                        "after": "30m",
+                        "notify": "phone",
+                        "target": "engineering_manager",
+                        "phone": "+353859876543",
+                    },
+                ],
+            }
+        )
+        manifest = parse_opensrm(data)
+        step = manifest.ownership.oncall.escalation[0]
+        assert step.after == "30m"
+        assert step.notify == "phone"
+        assert step.target == "engineering_manager"
+        assert step.phone == "+353859876543"
+
+    def test_roster_member_missing_name_raises(self):
+        """Roster member without name raises OpenSRMParseError."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "UTC",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"slack_id": "U01"}],  # missing name
+                },
+            }
+        )
+        with pytest.raises(OpenSRMParseError, match="roster.*missing required field"):
+            parse_opensrm(data)
+
+    def test_override_missing_user_raises(self):
+        """Override without user raises OpenSRMParseError."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "UTC",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"name": "Alice", "slack_id": "U01"}],
+                },
+                "overrides": [
+                    {"start": "2026-04-14T00:00:00Z", "end": "2026-04-21T00:00:00Z"},
+                ],  # missing user
+            }
+        )
+        with pytest.raises(OpenSRMParseError, match="overrides.*missing required field"):
+            parse_opensrm(data)
+
+    def test_escalation_missing_notify_raises(self):
+        """Escalation step without notify raises OpenSRMParseError."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "UTC",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"name": "Alice", "slack_id": "U01"}],
+                },
+                "escalation": [{"after": "5m"}],  # missing notify
+            }
+        )
+        with pytest.raises(OpenSRMParseError, match="escalation.*missing required field"):
+            parse_opensrm(data)
+
+    def test_missing_timezone_raises(self):
+        """Missing timezone raises OpenSRMParseError."""
+        data = self._make_manifest_with_oncall(
+            {
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"name": "Alice", "slack_id": "U01"}],
+                },
+            }
+        )
+        with pytest.raises(OpenSRMParseError, match="timezone is required"):
+            parse_opensrm(data)
+
+    def test_invalid_timezone_raises(self):
+        """Invalid timezone string raises OpenSRMParseError."""
+        data = self._make_manifest_with_oncall(
+            {
+                "timezone": "Europ/Dublin",
+                "rotation": {
+                    "type": "weekly",
+                    "handoff": "monday 09:00",
+                    "roster": [{"name": "Alice", "slack_id": "U01"}],
+                },
+            }
+        )
+        with pytest.raises(OpenSRMParseError, match="invalid IANA timezone"):
+            parse_opensrm(data)
 
 
 class TestOpenSRMParserGateEdgeCases:


### PR DESCRIPTION
## Summary
- Add `OnCallConfig` to `spec.ownership.oncall` — rotation, roster, overrides, escalation policy
- 5 new dataclasses: `RosterMember`, `Override`, `ManifestEscalationStep`, `RotationConfig`, `OnCallConfig`
- `_parse_oncall()` in opensrm_parser with timezone validation and `OpenSRMParseError` for malformed YAML
- 14 new tests (R5 reviewed — all 4 passes, all issues fixed)

Part of opensrm-0rg epic. nthlayer-respond PR (schedule resolver + escalation engine) depends on this.

## Test plan
- [ ] `uv run pytest tests/test_opensrm.py` — 132 tests pass
- [ ] `make test` — full suite green
- [ ] Verify existing ownership parsing unchanged (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)